### PR TITLE
TEST var issues- addressing data dropping and NA handling

### DIFF
--- a/src/micromet/format/reformatter.py
+++ b/src/micromet/format/reformatter.py
@@ -122,9 +122,10 @@ class Reformatter:
         df = df.pipe(transformers.timestamp_reset)
         df = df.pipe(transformers.fill_na_drop_dups, logger=self.logger)
 
+        df = df.pipe(transformers.apply_fixes, logger=self.logger)
         df, mask, report = transformers.apply_physical_limits(df)
 
-        df = df.pipe(transformers.apply_fixes, logger=self.logger)
+        
 
         if self.drop_soil:
             df = df.pipe(transformers.drop_extra_soil_columns, config=self.config, logger=self.logger)

--- a/src/micromet/format/transformers.py
+++ b/src/micromet/format/transformers.py
@@ -597,7 +597,7 @@ def rating(x):
     int
         The rating level (0, 1, or 2).
     """
-    if x is None:
+    if x is None or np.isnan(x):
         x = 0
     else:
         if 0 <= x <= 3:


### PR DESCRIPTION
moved apply_fixes above apply_physical_limits to prevent data being dropped
- updated if else statement for the rating to make sure np.nan values are given a 0
- note that almost all NAN values correspond with missing data for that parameter


I tested this on Escalante in detail and on Dugout, Pelican Lake, Matheson, and BFlast in less detail. All values properly converted to 0, 1, 2. I didn't see any fractions, though I'm not sure how this change would have fixed that. With Escalante, I compared the expected values in raw data versus in the processed data