### PR TITLE
changed DATETIME_START to DATETIME_END, modified DL to allow CSFLUX t…

### DIFF
--- a/docs/notebooks/DL.ipynb
+++ b/docs/notebooks/DL.ipynb
@@ -1001,12 +1001,16 @@
     "        df = pd.read_csv(file,skiprows=[0,2,3],\n",
     "                        na_values=[-9999,\"NAN\",\"NaN\",\"nan\"])\n",
     "        #print(df.columns)\n",
+    "        # must create a timestamp_end column to feed into prepare\n",
+    "        # b/c otherwise no data will be returned\n",
+    "        df[\"TIMESTAMP_END\"] = df.TIMESTAMP.dt.strftime(\"%Y%m%d%H%M\").astype(int)\n",
     "        df['TIMESTAMP'] = pd.to_datetime(df['TIMESTAMP'])\n",
     "        df['STATIONID']= key\n",
     "        \n",
     "\n",
-    "        am_df[name] = df #, report = am_data.prepare(df, data_type=\"eddy\")\n",
-    "        #outlier_report[key] = report\n",
+    "        csprep, report = am_data.prepare(df, data_type=\"eddy\")\n",
+    "        am_df[name] = csprep\n",
+    "        outlier_report[key] = report\n",
     "\n",
     "    comp_edd_df[key] = pd.concat(am_df,ignore_index=False)\n",
     "    \n",
@@ -2678,7 +2682,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "MicroMet",
+   "display_name": "pygis12v3",
    "language": "python",
    "name": "python3"
   },
@@ -2692,7 +2696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changed DATETIME_START column to DATETIME_END, changing code in several different functions. Changed DL to create a TIMESTAMP_END column to CSFlux (based on TIMESTAMP) to allow CSFlux to pass through micromet "prepare"

Tests:
datetime change: I compared raw data downloaded from easyflux and csflux to the same data passed through micromet, comparing based on TIMESTAMP columns in raw data and DATETIME_END in the processed data. I also compared data from the dataloggers to the other processed data. All data aligned.

DL change: I reviewed all of the prepare functions to review whether I thought any would negatively affect the csflux data. I also compared the output columns between data passed through prepare and data not such passed. 