### PR TITLE
Fix RTD build, SyntaxWarning, and core dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,3 +11,7 @@ pyyaml
 pytest
 requests
 pytz
+statsmodels
+scikit-learn
+windrose
+tzdata

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,7 @@ dependencies:
   - sqlalchemy
   - requests
   - pytz
+  - statsmodels
+  - scikit-learn
+  - windrose
+  - tzdata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ dependencies = [
     "pyyaml>=5.4",
     "requests>=2.25",
     "pytz>=2021.1",
+    "statsmodels",
+    "scikit-learn",
+    "windrose",
+    "tzdata",
 ]
 
 [project.optional-dependencies]
@@ -35,7 +39,6 @@ docs = [
     "myst-parser>=0.15",
 ]
 test = [
-    "python>=3.11",
     "pytest>=6.0",
     "pytest-cov>=2.0",
 ]

--- a/src/micromet/format/reformatter.py
+++ b/src/micromet/format/reformatter.py
@@ -124,9 +124,10 @@ class Reformatter:
                     "check_timestamps=True"
                 )
 
-    def prepare(self, df, interval, data_type="eddy"):
+    def prepare(self, df, interval=30, data_type="eddy"):
         """Current method - keep for backward compatibility"""
-        return self.process(df, interval=interval, data_type=data_type)
+        df, report, _ = self.process(df, interval=interval, data_type=data_type)
+        return df, report
 
     def preprocess(self, df, data_type="eddy", interval=30):
         """

--- a/src/micromet/qaqc/netrad_limits.py
+++ b/src/micromet/qaqc/netrad_limits.py
@@ -302,7 +302,10 @@ def _infer_freq_minutes(dt: pd.DatetimeIndex) -> int:
         If the index contains fewer than two timestamps or if the
         inferred interval is not positive.
     """
-    diffs = np.diff(dt.view("i8"))  # nanoseconds
+    # Ensure we are working with nanoseconds for consistent calculation
+    # pandas 3.0+ may use microseconds by default
+    dt_ns = pd.to_datetime(dt).values.astype("datetime64[ns]").view("i8")
+    diffs = np.diff(dt_ns)
     if len(diffs) == 0:
         raise ValueError("Need at least two timestamps to infer frequency.")
     med = np.median(diffs)

--- a/src/micromet/report/eddy_plots.py
+++ b/src/micromet/report/eddy_plots.py
@@ -801,7 +801,7 @@ def plot_flux_vs_ustar(
         title_str = "Daytime ($R_n > 10$)"
     else:
         subset = df[df[netrad_col] <= 10].copy()
-        title_str = "Nighttime ($R_n \leq 10$)"
+        title_str = r"Nighttime ($R_n \leq 10$)"
 
     if subset.empty:
         print("No data found for this mode.")

--- a/tests_micromet/test_netrad_limits.py
+++ b/tests_micromet/test_netrad_limits.py
@@ -97,7 +97,7 @@ def sample_netrad_df():
     # This is a simplified model for test purposes
     hours = dt_index.hour + dt_index.minute / 60
     sw_in = 1000 * np.sin(np.pi * hours / 24)**2 * (np.sin(np.pi * (dt_index.dayofyear - 80) / 365))
-    sw_in = sw_in.to_numpy() # Convert to numpy array to make it mutable
+    sw_in = sw_in.to_numpy().copy() # Convert to numpy array to make it mutable
     sw_in[sw_in < 0] = 0
 
     # Introduce a 1-hour lag

--- a/tests_micromet/test_reformatter.py
+++ b/tests_micromet/test_reformatter.py
@@ -51,6 +51,7 @@ def station_data_factory(tmp_path):
 def sample_reformatter_df():
     data = {
         'TIMESTAMP_START': ['202401010000', '202401010030', '202401010100'],
+        'TIMESTAMP_END': ['202401010030', '202401010100', '202401010130'],
         'Ta': [25.5, 26.0, 24.9],
         'Tau': [0.1, 0.0, 0.2],
         'u_star': [0.5, 0.6, 0.7],


### PR DESCRIPTION
This PR fixes the Read the Docs build issues by addressing a SyntaxWarning in `src/micromet/report/eddy_plots.py` and adding missing core dependencies (`statsmodels`, `scikit-learn`, `windrose`, `tzdata`) to `pyproject.toml`, `environment.yml`, and `docs/requirements.txt`.

Additionally, it fixes several regressions and bugs discovered during mandatory testing:
- Updated `_infer_freq_minutes` to handle both nanosecond and microsecond datetime resolutions (ensuring compatibility with Pandas 3.0+).
- Fixed a read-only `ValueError` in `tests_micromet/test_netrad_limits.py` by using `.copy()` on numpy arrays.
- Restored backward compatibility for `Reformatter.prepare` by adding a default `interval` and ensuring it returns only two values as expected by existing tests.
- Fixed `tests_micromet/test_reformatter.py` to provide consistent input data with both start and end timestamps.

All 24 tests in `tests_micromet/` now pass.

---
*PR created automatically by Jules for task [12912977918929526951](https://jules.google.com/task/12912977918929526951) started by @inkenbrandt*