### PR TITLE
test sign on TAU and turn to mostly negative if needed: tau_fixer

### DIFF
--- a/src/micromet/format/transformers/corrections.py
+++ b/src/micromet/format/transformers/corrections.py
@@ -32,19 +32,24 @@ def apply_fixes(df: pd.DataFrame, logger: logging.Logger) -> pd.DataFrame:
     pd.DataFrame
         The DataFrame with all fixes applied.
     """
-    df = tau_fixer(df)
+    df = tau_fixer(df, threshold=0.5, logger=logger)
     df = fix_swc_percent(df, logger)
     df = ssitc_scale(df, logger)
     return df
 
 
-def tau_fixer(df: pd.DataFrame) -> pd.DataFrame:
+def tau_fixer(df: pd.DataFrame, threshold: float = 0.5, logger: logging.Logger = None) -> pd.DataFrame:
     """
-    Replace zero values in the 'TAU' column with NaN.
+    Replace zero values in the 'TAU' column with NaN and flips sign if needed.
 
-    This function checks for zero values in the 'TAU' column and replaces
-    them with NaN. This is often done to handle cases where zero represents
+    Loops through all columns with TAU in the name that don't also have SSITC or QC in the name.
+
+    This function checks for zero values or negative infinity values in the 'TAU' column 
+    and replaces them with NaN. This is often done to handle cases where zero represents
     a missing or invalid measurement.
+
+    The function also determines whether to reverse the sign of TAU. If more than the specified 
+    threshold of TAU values are positive, it flips the sign of all TAU values. 
 
     Parameters
     ----------
@@ -56,10 +61,27 @@ def tau_fixer(df: pd.DataFrame) -> pd.DataFrame:
     pd.DataFrame
         The DataFrame with zero values in 'TAU' replaced by NaN.
     """
-    if "TAU" in df.columns and "U_STAR" in df.columns:
-        bad_idx = df["TAU"] == 0
-        df.loc[bad_idx, "TAU"] = np.nan
-    return df
+    df2 = df.copy()
+    tau_mask = df2.columns.str.contains('TAU')
+    ssitc_mask = df2.columns.str.contains('SSITC')
+    qc_mask = df2.columns.str.contains('QC')
+    tau_col = df2.columns[tau_mask & ~ssitc_mask & ~qc_mask]
+    logger.debug(f"TAU columns identified for fixing: {tau_col.tolist()}")
+    for col in tau_col:
+        bad_idx = (df2[col] == 0) | (df2[col] == -np.inf)
+        df2.loc[bad_idx, col] = np.nan
+
+        positive_mask = (df2[col] > 0)
+        negative_mask = (df2[col] < 0)
+
+        percent_positive = positive_mask.sum()/(positive_mask.sum() + 
+                                                negative_mask.sum())
+        if percent_positive > threshold:
+            df2[col] *= -1
+            logger.debug(f"{col} values were flipped for station due to {percent_positive:.2%} of values being positive.")
+        else:
+            logger.debug(f"{col} values were not flipped for station due to only {percent_positive:.2%} of values being positive.")
+    return df2
 
 
 def fix_swc_percent(df: pd.DataFrame, logger: logging.Logger) -> pd.DataFrame:


### PR DESCRIPTION
- updated tau_fixer function to turn -infinity values to np.nan (there were 8 at Bluff) and flip sign on Tau when Tau is predominantly negative
- updated tau_fixer to find column like TAU_1_1_1 and not just TAU and to loop through muptiple Tau columns, avoiding any with SSITC or QC in the name
- I tested this at Myton, Bluff, and Cedar Mesa with good results. At Myton, I tested with a dataframe with two Tau columns in the dataframe with good results