### PR TITLE
Bump version to 0.5.0 and update documentation for processing workflo…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ import micromet
 project = "micromet"
 copyright = "2026, Paul Inkenbrandt, Kathryn Ladig, Diane Menuz"
 author = "Paul Inkenbrandt, Kathryn Ladig, Diane Menuz"
-release = "0.4.5"
+release = "0.5.0"
 
 master_doc = "index"  # The name of the master document (without the .rst extension)
 # -- General configuration ---------------------------------------------------
@@ -23,12 +23,15 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_autodoc_typehints",
     "myst_parser",
+    "nbsphinx",
 ]
 
 source_suffix = {
     ".rst": "restructuredtext",
     ".md": "markdown",
 }
+
+nbsphinx_execute = "never"  # Do not re-execute notebooks during build
 
 templates_path = ["_templates"]
 exclude_patterns = [

--- a/docs/data_processing.rst
+++ b/docs/data_processing.rst
@@ -3,25 +3,112 @@ Data Processing and Management
 
 This section explains how Utah Flux Network data are processed and managed using Python.
 
+For a complete end-to-end walkthrough of the processing pipeline, see the :doc:`flux_workflow_summary` and :doc:`flux_processing_workflow` pages. The :doc:`notebooks` page describes worked example notebooks that illustrate each stage.
+
 Modules
 -------
 
-**1. `converter.py`**
-- `AmerifluxDataProcessor`: Parses AmeriFlux TOA5 CSVs into pandas DataFrames.
-- `Reformatter`: Cleans, standardizes, and resamples data using timestamp inference, column renaming, and soil sensor logic.
+**format subpackage**
 
-**2. `tools.py`**
-- Detects irrigation events (`find_irr_dates`)
-- Identifies missing data gaps and visualizes them (`find_gaps`, `plot_gaps`)
-- Flags extreme variations
+**1. ``format/reformatter.py``**
 
-**3. `graphs.py`**
-- `energy_sankey()`: Visualizes daily energy balance as Sankey diagrams
-- `scatterplot_instrument_comparison()`: Compares instruments with regression stats
+- ``AmerifluxDataProcessor``: Parses AmeriFlux TOA5 CSVs and Campbell Scientific ``.dat`` files into pandas DataFrames.
+- ``Reformatter``: Cleans, standardizes, and resamples data through three pipeline stages:
 
-**4. `headers.py`**
-- Utilities for detecting and applying missing headers across files
+  - ``preprocess()``: Strips suffixes, renames columns, validates timestamps, and subsets to target interval.
+  - ``finalize()``: Applies physical limits, replaces out-of-range values, and generates a QC report.
+  - ``prepare()``: Convenience wrapper combining preprocess and finalize.
 
-**5. `station_data_pull.py`**
-- Fetches logger data over HTTP from remote stations
-- Compares and inserts data into SQL databases
+**2. ``format/file_compile.py``**
+
+- ``compile_files()``: Compiles multiple raw ``.dat`` files from a directory into a single concatenated DataFrame, handling overlapping records and header mismatches.
+
+**3. ``format/merge.py``**
+
+- Functions for merging eddy covariance and meteorological data streams, resolving column conflicts, and applying suffix conventions (``_EDDY`` / ``_MET``).
+
+**4. ``format/compare.py``**
+
+- Cross-correlation and lag-detection functions used to align sensor streams with systematic time offsets.
+
+**5. ``format/headers.py``**
+
+- Utilities for detecting and applying missing headers across files, particularly for Campbell Scientific TOA5 format data.
+
+**6. ``format/transformers/``**
+
+- ``columns``: Column renaming, suffix standardisation, and duplicate resolution.
+- ``timestamps``: Timestamp parsing, correction, and format conversion.
+- ``corrections``: Calibration corrections (precipitation, soil heat flux, sign inversions).
+- ``validation``: Range checks and flag generation.
+- ``cleanup``: Removal of all-NaN columns and artefact records.
+- ``interval_updates``: Filtering data to a target measurement interval via ``subset_interval()``.
+
+----
+
+**qaqc subpackage**
+
+**7. ``qaqc/variable_limits.py``**
+
+- Dictionary defining physical and plausible ranges for every AmeriFlux variable, used by ``Reformatter.finalize()`` to flag and replace out-of-range values.
+
+**8. ``qaqc/netrad_limits.py``**
+
+- Net radiation QA/QC: timestamp alignment checks and signal-strength filtering for radiation sensors.
+
+**9. ``qaqc/data_cleaning.py``**
+
+- Applies QC flags to data, including signal-strength thresholds for IRGA variables (CO₂ and H₂O).
+
+----
+
+**report subpackage**
+
+**10. ``report/graphs.py``**
+
+- ``energy_sankey()``: Visualizes daily energy balance as Sankey diagrams.
+- ``scatterplot_instrument_comparison()``: Compares instruments with regression statistics and Bland–Altman plots.
+
+**11. ``report/tools.py``**
+
+- ``find_irr_dates()``: Detects irrigation events from precipitation and soil moisture data.
+- ``find_gaps()`` / ``plot_gaps()``: Identifies and visualizes missing data periods.
+
+**12. ``report/validate.py``**
+
+- ``review_lags()``: Cross-correlation lag detection between sensor columns.
+- ``detect_sectional_offsets_indexed()``: Detects systematic time offsets between eddy and meteorological systems.
+
+**13. ``report/fix_g_values.py``**
+
+- Soil heat flux storage corrections: adjusts ``G_PLATE`` measurements for sensor burial depth differences.
+
+**14. ``report/recalculate_albedo.py``**
+
+- Recalculates albedo from shortwave radiation components when primary albedo values are missing or erroneous.
+
+**15. ``report/gap_summary.py``**
+
+- Generates tabular summaries of data gap statistics by variable and time period.
+
+**16. ``report/eddy_plots.py``**
+
+- Diagnostic plots for eddy covariance data using Bokeh and Plotly, including time-series and footprint overlays.
+
+**17. ``report/easyflux_footprint.py``**
+
+- Flux footprint estimation using EasyFlux outputs, including spatial extent and directional analysis.
+
+**18. ``report/alfalfa_growth.py``**
+
+- ``AlfalfaHeightParams``: Dataclass for site-specific alfalfa height model parameters.
+- ``simulate_alfalfa_height_multi_field()``: Simulates alfalfa canopy height from growing degree days (GDD) across multiple cuttings and fields.
+
+----
+
+**station_data_pull**
+
+**19. ``station_data_pull.py``**
+
+- ``StationDataDownloader``: Fetches logger data over HTTP from remote Campbell Scientific stations.
+- ``StationDataProcessor``: Compares and inserts downloaded data into SQL databases.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -9,16 +9,19 @@ Installation
 ------------
 
 Micromet is available on PyPI and can be installed using pip:
+
 .. code-block:: bash
 
     pip install micromet
 
 Alternatively, if you want to use the latest development version, you can install it directly from GitHub:
+
 .. code-block:: bash
 
     pip install git+https://github.com/inkenbrandt/MicroMet.git
 
 MicroMet is also available as a conda package. You can install it using the following command:
+
 .. code-block:: bash
 
     conda install -c conda-forge micromet
@@ -38,17 +41,11 @@ It's recommended to use a virtual environment:
     python -m venv .venv
     source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
-Install dependencies:
+Install the package with optional documentation and development dependencies:
 
 .. code-block:: bash
 
-    pip install -r requirements.txt
-
-To install in editable/development mode:
-
-.. code-block:: bash
-
-    pip install -e .
+    pip install -e .[docs,test]
 
 Usage Overview
 --------------
@@ -57,7 +54,7 @@ Micromet consists of modular tools for reformatting and analyzing micrometeorolo
 
 .. code-block:: python
 
-    from micromet.converter import Reformatter
+    from micromet.format.reformatter import Reformatter
 
     # Load your raw data into a pandas DataFrame
     import pandas as pd
@@ -65,24 +62,49 @@ Micromet consists of modular tools for reformatting and analyzing micrometeorolo
 
     # Create a Reformatter instance and process the data
     ref = Reformatter()
-    tidy_df = ref.prepare(df)
+    cleaned_df, report = ref.prepare(df, data_type='eddy')
 
-    # Now tidy_df contains the cleaned and normalized data
-    print(tidy_df.head())
+    # Now cleaned_df contains the cleaned and normalized data
+    print(cleaned_df.head())
 
 Modules
 -------
 
-The key modules in Micromet are:
+The key subpackages and modules in Micromet are:
 
-- ``converter`` — Reformat raw CSV files into tidy dataframes
-- ``tools`` — Utility functions for timestamp alignment and filtering
-- ``headers`` — Functions for renaming columns and interpreting header metadata
-- ``station_data_pull`` — (Optional) Pull and organize station-specific data files
+- ``format`` — Data formatting subpackage:
+
+  - ``reformatter`` — Main :class:`~micromet.format.reformatter.Reformatter` class for cleaning and standardizing data
+  - ``file_compile`` — Utilities for compiling multiple raw ``.dat`` files into a single dataset
+  - ``merge`` — Functions for merging eddy covariance and met data streams
+  - ``compare`` — Instrument comparison and cross-correlation functions
+  - ``headers`` — Utilities for detecting and applying missing headers across files
+  - ``transformers`` — Data transformation submodule (``columns``, ``timestamps``, ``corrections``, ``validation``, ``cleanup``, ``interval_updates``)
+
+- ``qaqc`` — Quality assurance and control subpackage:
+
+  - ``variable_limits`` — Physical and plausible range definitions for all variables
+  - ``netrad_limits`` — Net radiation QA/QC and timestamp alignment
+  - ``data_cleaning`` — QC flag application and data cleaning
+
+- ``report`` — Reporting and visualization subpackage:
+
+  - ``graphs`` — Plotting functions (energy Sankey diagrams, instrument comparison scatter plots)
+  - ``tools`` — Utility functions for analysis (irrigation event detection, gap finding)
+  - ``validate`` — Data validation, lag detection, and sensor intercomparison
+  - ``fix_g_values`` — Soil heat flux storage corrections
+  - ``recalculate_albedo`` — Albedo recalculation utilities
+  - ``gap_summary`` — Gap analysis and reporting
+  - ``eddy_plots`` — Eddy covariance diagnostic plots
+  - ``easyflux_footprint`` — Flux footprint analysis
+  - ``alfalfa_growth`` — Alfalfa height modeling from growing degree days
+
+- ``reader`` — :class:`~micromet.reader.AmerifluxDataProcessor` for reading AmeriFlux and TOA5 data files
+- ``station_data_pull`` — :class:`~micromet.station_data_pull.StationDataDownloader` and :class:`~micromet.station_data_pull.StationDataProcessor` for managing station data
 
 .. note::
 
-   The ``Notebooks`` directory is intended for exploratory analysis and is not part of the core API documentation.
+   The ``notebooks/`` directory contains worked examples and is not part of the core API. See :doc:`notebooks` for a guide to the available notebooks.
 
 Contributing
 ------------
@@ -98,7 +120,8 @@ Please make sure to add unit tests for new functionality and follow PEP8 standar
 Further Reading
 ---------------
 
-- :doc:`api`
-- :doc:`usage_examples`
+- :doc:`modules`
+- :doc:`data_processing`
+- :doc:`flux_workflow_summary`
 - `Micromet on GitHub <https://github.com/inkenbrandt/MicroMet>`_
-
+- `Full documentation on Read the Docs <https://micromet.readthedocs.io/en/latest/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to Micromet's documentation!
    data_processing
    flux_workflow_summary
    flux_processing_workflow
+   notebooks
    modules
    about_ufn
    ameriflux_variables

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -1,0 +1,62 @@
+Example Notebooks
+=================
+
+The ``docs/notebooks/`` directory contains Jupyter Notebooks that demonstrate the MicroMet processing workflow and package capabilities. Each notebook corresponds to a stage of the end-to-end pipeline described in :doc:`flux_workflow_summary`.
+
+.. note::
+
+   Notebooks are provided for reference and are not re-executed during documentation builds. Data files required by some notebooks (large CSVs, station ``.dat`` files) are not included in the repository.
+
+Processing Workflow Notebooks
+------------------------------
+
+These notebooks implement the numbered processing steps for a flux station (see :doc:`flux_processing_workflow` for full technical details).
+
+.. toctree::
+   :maxdepth: 1
+
+   notebooks/cs_files
+   notebooks/Appending Data From Dataloggers
+   notebooks/netrad_limits_getting_started
+   notebooks/Sensor Comparisons
+   notebooks/DL_forAmeriFluxOutputOnly
+   notebooks/footprint_recalculation
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Notebook
+     - Description
+   * - ``cs_files.ipynb``
+     - Reads and compiles Campbell Scientific ``.dat`` files; demonstrates ``file_compile`` and ``Reformatter.preprocess()`` for CS-format eddy data (workflow Step 1).
+   * - ``Appending Data From Dataloggers.ipynb``
+     - Merges data downloaded directly from dataloggers with compiled station archives; covers gap-filling and timestamp alignment (workflow Steps 1–2).
+   * - ``netrad_limits_getting_started.ipynb``
+     - Applies net radiation QA/QC and physical limit checks using ``qaqc.netrad_limits`` and ``Reformatter.finalize()`` (workflow Step 3).
+   * - ``Sensor Comparisons.ipynb``
+     - Side-by-side instrument intercomparison using ``report.validate`` and ``report.graphs.scatterplot_instrument_comparison()`` (workflow Step 3a).
+   * - ``DL_forAmeriFluxOutputOnly.ipynb``
+     - Exports a quality-controlled dataset to AmeriFlux-formatted CSV: signal-strength filtering, column dropping, timestamp formatting, and −9999 fill (workflow Step 4).
+   * - ``footprint_recalculation.ipynb``
+     - Estimates and maps the flux footprint from EasyFlux outputs using ``report.easyflux_footprint`` (supplemental analysis).
+
+Analysis and Utility Notebooks
+--------------------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Notebook
+     - Description
+   * - ``converter_tutorial (2).ipynb``
+     - Introductory tutorial for the ``Reformatter`` class: loading raw data, running ``prepare()``, and inspecting the QC report.
+   * - ``graphs_usage_example.ipynb``
+     - Examples of all major plotting functions in ``report.graphs``, including energy Sankey diagrams and instrument comparison scatter plots.
+   * - ``fix_headers.ipynb``
+     - Demonstrates ``format.headers`` utilities for detecting and applying missing column headers across a set of ``.dat`` files.
+   * - ``Pull DB Data and Impute.ipynb``
+     - Retrieves gap-filled reference data from the UGS database and performs meteorological variable imputation.
+   * - ``alfalfa_height.ipynb``
+     - Simulates alfalfa canopy height using growing degree days via ``report.alfalfa_growth.simulate_alfalfa_height_multi_field()``, calibrated with experimental data from Wellington, UT (January 2023 – December 2024).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,10 @@
 sphinx
 sphinx-autodoc-typehints
 sphinx-rtd-theme
+sphinx-copybutton
 myst-parser
+nbsphinx
+ipykernel
 pandas
 numpy
 plotly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "micromet"
 description = "A comprehensive Python package for micrometeorological data analysis"
 readme = "README.md"
-version = "0.4.5"
+version = "0.5.0"
 requires-python = ">=3.11"
 license = {text = "GNU General Public License v3.0"}
 authors = [
@@ -37,6 +37,8 @@ docs = [
     "sphinx-copybutton>=0.5",
     "sphinx-autodoc-typehints>=1.12",
     "myst-parser>=0.15",
+    "nbsphinx>=0.8",
+    "ipykernel>=6.0",
 ]
 test = [
     "pytest>=6.0",

--- a/src/micromet/__init__.py
+++ b/src/micromet/__init__.py
@@ -47,7 +47,7 @@ from .format.transformers import (
     MISSING_VALUE,
 )
 
-__version__ = "0.4.5"
+__version__ = "0.5.0"
 
 __all__ = [
     "AmerifluxDataProcessor",


### PR DESCRIPTION
…w notebooks

- Bump version from 0.4.5 to 0.5.0 in pyproject.toml, docs/conf.py, and __init__.py
- Add nbsphinx and ipykernel to docs requirements and pyproject.toml [docs] extra
- Add nbsphinx extension to conf.py (execute=never to avoid re-running large notebooks)
- Fix broken import in getting_started.rst (micromet.converter → micromet.format.reformatter)
- Fix broken :doc: cross-references in getting_started.rst (api, usage_examples → modules, data_processing, flux_workflow_summary)
- Update getting_started.rst module list to reflect actual format/qaqc/report subpackage structure
- Rewrite data_processing.rst to document all 19 current modules across subpackages
- Add docs/notebooks.rst cataloguing all workflow and analysis notebooks with descriptions
- Add notebooks to docs/index.rst toctree